### PR TITLE
redis: support unix path

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ const config = {
     host: process.env.REDIS_HOST as string,
     port: Number(process.env.REDIS_PORT as string),
     keyPrefix: process.env.REDIS_PREFIX as string,
+    path: process.env.REDIS_PATH as string,
     ...((() => {
       const password = process.env.REDIS_PASSWORD as (string | undefined)
       


### PR DESCRIPTION
accessing redis via unix socket allows more fine-grained permissions than tcp